### PR TITLE
Fix issue with description not parsed properly

### DIFF
--- a/src/ical.ts
+++ b/src/ical.ts
@@ -700,7 +700,7 @@ export function parseLines(lines: string | any[], limit: number, ctx?: { type?: 
         }
 
         // Remove any double quotes in any tzid statement// except around (utc+hh:mm
-        if (l.indexOf('TZID=') && !l.includes('"(')) {
+        if (l.includes('TZID=') && !l.includes('"(')) {
             l = l.replace(/"/g, '');
         }
 


### PR DESCRIPTION
This fixes an issue when parameters have quotes.

Example:
```
var ics = 'BEGIN:VCALENDAR\nVERSION:2.0\nCALSCALE:GREGORIAN\nPRODID:-//SabreDAV//SabreDAV//EN\nX-WR-CALNAME:Réunions (skeptikon)\nREFRESH-INTERVAL;VALUE=DURATION:PT4H\nX-PUBLISHED-TTL:PT4H\nBEGIN:VTIMEZONE\nTZID:Europe/Paris\nBEGIN:DAYLIGHT\nTZOFFSETFROM:+0100\nTZOFFSETTO:+0200\nTZNAME:CEST\nDTSTART:19700329T020000\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=3\nEND:DAYLIGHT\nBEGIN:STANDARD\nTZOFFSETFROM:+0200\nTZOFFSETTO:+0100\nTZNAME:CET\nDTSTART:19701025T030000\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=10\nEND:STANDARD\nEND:VTIMEZONE\nBEGIN:VEVENT\nCREATED:20211221T203943Z\nLAST-MODIFIED:20211221T204003Z\nDTSTAMP:20211221T204003Z\nUID:a08c557a-3836-48ac-894b-2b4b45934ad7\nSUMMARY:Foobar\nDTSTART;TZID=Europe/Paris:20211224T191500\nDTEND;TZID=Europe/Paris:20211224T201500\nTRANSP:OPAQUE\nDESCRIPTION;ALTREP="data:text/html,%3Cbody%3E%0A%3Cdiv%3EHey%20%22%3Cb%3Eyo\n uhou%3C%2Fb%3E%22%3C%2Fdiv%3E%0A%3C%2Fbody%3E":Hey "youhou"\n\nBEGIN:VALARM\nACTION:DISPLAY\nTRIGGER;VALUE=DURATION:-PT15M\nDESCRIPTION:Description par défaut Mozilla\nEND:VALARM\nEND:VEVENT\nEND:VCALENDAR\n'

ical.parseICS(ics)
```

Output before fix:
```
...
'a08c557a-3836-48ac-894b-2b4b45934ad7': {
    type: 'VEVENT',
    params: [],
    description: {
      params: [Object],
      val: 'text/html,%3Cbody%3E%0A%3Cdiv%3EHey%20%22%3Cb%3Eyouhou%3C%2Fb%3E%22%3C%2Fdiv%3E%0A%3C%2Fbody%3E:Hey youhou'
    },
...
```
Output after fix:
```
...
  'a08c557a-3836-48ac-894b-2b4b45934ad7': {
...
    description: { params: [Object], val: 'Hey "youhou"' },
...
  }
```
